### PR TITLE
dropped railsexpress backport-401c8bb as it has been merged to ruby_2_2

### DIFF
--- a/patchsets/ruby/2.2/head/railsexpress
+++ b/patchsets/ruby/2.2/head/railsexpress
@@ -1,4 +1,3 @@
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2/head/railsexpress/01-zero-broken-tests.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2/head/railsexpress/02-improve-gc-stats.patch
 https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2/head/railsexpress/03-display-more-detailed-stack-trace.patch
-https://raw.githubusercontent.com/skaes/rvm-patchsets/master/patches/ruby/2.2/head/railsexpress/04-backport-401c8bb.patch


### PR DESCRIPTION
can you please merge?

otherwise railsexpress head patches will fail against current ruby-2_2 head