### PR TITLE
Add llvm-dev to rbx requirements

### DIFF
--- a/scripts/functions/requirements/ubuntu
+++ b/scripts/functions/requirements/ubuntu
@@ -103,7 +103,7 @@ requirements_debian_define()
       ;;
 
     (rbx*|rubinius*)
-      requirements_ubuntu_libs_default clang llvm
+      requirements_ubuntu_libs_default clang llvm llvm-dev
       rvm_configure_flags+=( --cc=clang --cxx=clang++ )
       ;;
 


### PR DESCRIPTION
Hi Michal!

Failed on my Mint 17.1 machine/ubuntu based system, runs fine with the lib installed. Hope that this is the right place :)

Error running '/home/tobi/.rvm/wrappers/ruby-2.2.0@rubinius/rake install --trace',
showing last 15 lines of /home/tobi/.rvm/log/1421001055_rbx-2.4.1/rake.log
4: CXX vm/builtin/list.cpp
In file included from vm/builtin/jit.cpp:7:
/home/tobi/.rvm/src/rbx-2.4.1/vm/llvm/state.hpp:10:10: fatal error: 'llvm/IR/Module.h' file not found
#include <llvm/IR/Module.h>

Cheers,
Tobi