### PR TITLE
sudo path hint

### DIFF
--- a/scripts/rvm
+++ b/scripts/rvm
@@ -214,6 +214,13 @@ then
 Warning: PATH set to RVM ruby but GEM_HOME and/or GEM_PATH not set, see:
     https://github.com/wayneeseguin/rvm/issues/3212
 " >&2
+        if
+          [[ -n "${SUDO_USER:-}" ]]
+        then
+          echo "Hint: To fix PATH errors try using 'rvmsudo' instead of 'sudo', see:
+    http://stackoverflow.com/questions/27784961/received-warning-message-path-set-to-rvm-after-updating-ruby-version-using-rvm/28080063#28080063
+" >&2
+        fi
       fi
       unset __path_to_ruby
 


### PR DESCRIPTION
Adds a hint to use `rvmsudo` when `GEM_HOME` and `GEM_PATH` aren't set in `sudo` shell.