### PR TITLE
Change UID check to id -u

### DIFF
--- a/binscripts/rvm-installer
+++ b/binscripts/rvm-installer
@@ -523,7 +523,7 @@ rvm_install_default_settings()
     [[ -z "${rvm_path:-}" ]]
   then
     if
-      (( UID == 0 ))
+      (( $( id -u ) == 0 ))
     then
       rvm_user_install_flag=0
       rvm_prefix="/usr/local"


### PR DESCRIPTION
This fixes issue #3276 

The multi-user installation is not working in Ubuntu, because the script checks if it was run with sudo using ` UID == 0 `, but that doesn't work in Ubuntu 12.04 nor Ubuntu 14.04. 

You can check (at an Ubuntu machine) with:
```
$ echo $UID # should return a normal user ID number, as 1000
1000
$ sudo echo $UID # the script expects 0, but the result is the same as without sudo
1000
```
I also checked that under CentOS 6.5, and the behaviour is the same, so, probably the problem also occurs under CentOS 6.5.

-------------------

The way to find out if the script was run by sudo is with `id -u`, you can check (at an Ubuntu or CentOS machine) with:
```
$ id -u # should return a normal user ID number, as 1000
1000
$ sudo id -u # the script could expect 0, and the result would actually be 0
0
```
