### PR TITLE
Ignore ~/.rvmrc and /etc/rvmrc when --path is specified

### DIFF
--- a/scripts/functions/installer
+++ b/scripts/functions/installer
@@ -213,6 +213,7 @@ parse_args()
       (--path)
         export rvm_path="$1"
         export rvm_bin_path="$1/bin"
+        export rvm_ignore_rvmrc=1
         shift
         ;;
       (--add-to-rvm-group)


### PR DESCRIPTION
The `--path` parameter is not respected when installing (./install) if rvm_path and/or rvm_bin_path is defined in `~/.rvmrc` or `/etc/rvmrc`.

Not sure if it's desirable to ignore the whole rvmrc; is the install script supposed to respect other parameters from rvmrc?