### PR TITLE
Remove quotes inside arithmetic expression

### DIFF
--- a/scripts/functions/build_requirements
+++ b/scripts/functions/build_requirements
@@ -113,7 +113,7 @@ __rvm_requirements_run_summary()
   }
   (( ${#packages_installed[@]} == 0 )) ||
   {
-    if (( "${rvm_list_installed_packages_flag:-0}" == 1 ))
+    if (( ${rvm_list_installed_packages_flag:-0} == 1 ))
     then
       requirements_print_list ${packages_installed[*]}
     fi


### PR DESCRIPTION
Prevents a possible `__rvm_requirements_run_summary:12: bad math expression: illegal character: "` warning.