### PR TITLE
+ruby-2.2.1

### DIFF
--- a/config/known
+++ b/config/known
@@ -8,6 +8,7 @@
 [ruby-]2.1.4
 [ruby-]2.1[.5]
 [ruby-]2.2.0
+[ruby-]2.2.1
 [ruby-]2.2-head
 ruby-head
 


### PR DESCRIPTION
2.2.1 listed in the cache http://cache.ruby-lang.org/pub/ruby/.. but it is not listed on the download page (https://www.ruby-lang.org/en/downloads/) yet!