### PR TITLE
Added -lz to ruby build flags

### DIFF
--- a/scripts/functions/build_config
+++ b/scripts/functions/build_config
@@ -301,7 +301,7 @@ __rvm_setup_compile_environment_flags_shared_static()
         ;;
       (*)
         rvm_configure_flags+=( --disable-shared )
-        __rvm_setup_compile_environment_flags_static_darwin LDFLAGS="-Bstatic"
+        __rvm_setup_compile_environment_flags_static_darwin LDFLAGS="-Bstatic -lz"
         ;;
     esac
   else


### PR DESCRIPTION
This prevents an openssl bug where it requires -lz when it's statically linked but it isn't available by default.

For example, this was causing issues with building the puma gem:
```ruby
 require 'mkmf'

 have_library 'crypto', 'BIO_read'
 #>> checking for BIO_read() in -lcrypto... yes
 #=> true

 # The puma build fails here:
 have_library 'ssl', 'SSL_CTX_new'
 #>> checking for SSL_CTX_new() in -lssl... no
 #=> false

 # With zlib it succeeds:
 have_library 'z'
 #>> checking for main() in -lz... yes
 #=> true

 have_library 'ssl', 'SSL_CTX_new'
 #>> checking for SSL_CTX_new() in -lssl... yes
 #=> true
```